### PR TITLE
Add link and verify endpoints

### DIFF
--- a/src/MonkeyButler.Abstractions/Business/ILinkCharacterManager.cs
+++ b/src/MonkeyButler.Abstractions/Business/ILinkCharacterManager.cs
@@ -1,0 +1,17 @@
+﻿using MonkeyButler.Abstractions.Business.Models.LinkCharacter;
+
+namespace MonkeyButler.Abstractions.Business;
+
+/// <summary>
+/// Manager for linking a character to a discord user.
+/// </summary>
+public interface ILinkCharacterManager
+{
+    /// <summary>
+    /// Links the character in the query to the discord user.
+    /// </summary>
+    /// <param name="criteria">The criteria for this request.</param>
+    /// <returns>The processed the result.</returns>
+    Task<LinkCharacterResult> Process(LinkCharacterCriteria criteria);
+}
+

--- a/src/MonkeyButler.Abstractions/Business/Models/LinkCharacter/LinkCharacterCriteria.cs
+++ b/src/MonkeyButler.Abstractions/Business/Models/LinkCharacter/LinkCharacterCriteria.cs
@@ -1,0 +1,22 @@
+﻿namespace MonkeyButler.Abstractions.Business.Models.LinkCharacter;
+
+/// <summary>
+/// The criteria for linking a character to a user.
+/// </summary>
+public record LinkCharacterCriteria
+{
+    /// <summary>
+    /// The Discord Id of the user.
+    /// </summary>
+    public ulong UserId { get; set; }
+
+    /// <summary>
+    /// The guildId of the guild for verification
+    /// </summary>
+    public ulong GuildId { get; set; }
+
+    /// <summary>
+    /// The query including the name of the user.
+    /// </summary>
+    public string Query { get; set; }
+}

--- a/src/MonkeyButler.Abstractions/Business/Models/LinkCharacter/LinkCharacterResult.cs
+++ b/src/MonkeyButler.Abstractions/Business/Models/LinkCharacter/LinkCharacterResult.cs
@@ -1,0 +1,22 @@
+﻿namespace MonkeyButler.Abstractions.Business.Models.LinkCharacter;
+
+/// <summary>
+/// Result of linking a character
+/// </summary>
+public record LinkCharacterResult
+{
+    /// <summary>
+    /// Indicator of whether it was successful.
+    /// </summary>
+    public bool Success { get; set; } = false;
+
+    /// <summary>
+    /// Message if there is a failure.
+    /// </summary>
+    public string? FailureMessage { get; set; }
+
+    /// <summary>
+    /// The linked character Id.
+    /// </summary>
+    public long? CharacterId { get; set; }
+}

--- a/src/MonkeyButler.Business/Managers/LinkCharacterManager.cs
+++ b/src/MonkeyButler.Business/Managers/LinkCharacterManager.cs
@@ -49,7 +49,7 @@ internal class LinkCharacterManager : ILinkCharacterManager
             Server = server,
         });
 
-        var character = searchData.Results.SingleOrDefault();
+        var character = searchData.Results?.SingleOrDefault();
 
         if (character is null)
         {
@@ -70,7 +70,8 @@ internal class LinkCharacterManager : ILinkCharacterManager
 
         return new()
         {
-            Success = true
+            Success = true,
+            CharacterId = characterId,
         };
     }
 }

--- a/src/MonkeyButler.Business/Managers/LinkCharacterManager.cs
+++ b/src/MonkeyButler.Business/Managers/LinkCharacterManager.cs
@@ -1,0 +1,76 @@
+﻿using FluentValidation;
+using Microsoft.Extensions.Logging;
+using MonkeyButler.Abstractions.Business;
+using MonkeyButler.Abstractions.Business.Models.LinkCharacter;
+using MonkeyButler.Abstractions.Data.Api;
+using MonkeyButler.Abstractions.Data.Storage;
+using MonkeyButler.Business.Engines;
+
+namespace MonkeyButler.Business.Managers;
+
+internal class LinkCharacterManager : ILinkCharacterManager
+{
+    private readonly IGuildOptionsAccessor _guildOptionsAccessor;
+    private readonly IUserAccessor _userAccessor;
+    private readonly IXivApiAccessor _xivApiAccessor;
+    private readonly ILogger<LinkCharacterManager> _logger;
+    private readonly IValidator<LinkCharacterCriteria> _validator;
+
+    public LinkCharacterManager(
+        IGuildOptionsAccessor guildOptionsAccessor,
+        IUserAccessor userAccessor,
+        IXivApiAccessor xivApiAccessor,
+        ILogger<LinkCharacterManager> logger,
+        IValidator<LinkCharacterCriteria> validator)
+    {
+        _guildOptionsAccessor = guildOptionsAccessor;
+        _userAccessor = userAccessor;
+        _xivApiAccessor = xivApiAccessor;
+        _logger = logger;
+        _validator = validator;
+    }
+
+    public async Task<LinkCharacterResult> Process(LinkCharacterCriteria criteria)
+    {
+        _validator.ValidateAndThrow(criteria);
+
+        (var name, _) = NameServerEngine.Parse(criteria.Query);
+        var optionsResult = await _guildOptionsAccessor.GetOptions(new()
+        {
+            GuildId = criteria.GuildId
+        });
+
+        var server = optionsResult?.FreeCompany?.Server;
+
+        _logger.LogTrace("Searching for character with name {Name} and server {Server}", name, server);
+        var searchData = await _xivApiAccessor.SearchCharacter(new()
+        {
+            Name = name,
+            Server = server,
+        });
+
+        var character = searchData.Results.SingleOrDefault();
+
+        if (character is null)
+        {
+            return new()
+            {
+                Success = false,
+                FailureMessage = $"Could not find character! Query '{criteria.Query}'; Server '{server}'"
+            };
+        }
+
+        var characterId = character.Id;
+        _logger.LogDebug("Got character for {Name}: Id {Id}", name, characterId);
+
+        var dataUser = await _userAccessor.GetUser(criteria.UserId) ?? new() { Id = criteria.UserId };
+        var mergedUser = dataUser.Merge(characterId);
+
+        await _userAccessor.SaveUser(mergedUser);
+
+        return new()
+        {
+            Success = true
+        };
+    }
+}

--- a/src/MonkeyButler.Business/Managers/VerifyCharacterManager.cs
+++ b/src/MonkeyButler.Business/Managers/VerifyCharacterManager.cs
@@ -131,6 +131,7 @@ internal class VerifyCharacterManager : IVerifyCharacterManager
         }
 
         result.Status = Status.Verified;
+        result.VerifiedUserId = criteria.UserId;
         _logger.LogDebug("{Name} has been verified with Free Company Id {FcId}.", result.Name, guildOptions.FreeCompany.Id);
 
         // Save character-user map to database.

--- a/src/MonkeyButler.Business/Validators/LinkCharacter/LinkCharacterCriteriaValidator.cs
+++ b/src/MonkeyButler.Business/Validators/LinkCharacter/LinkCharacterCriteriaValidator.cs
@@ -10,6 +10,9 @@ internal class LinkCharacterCriteriaValidator : AbstractValidator<LinkCharacterC
         RuleFor(x => x.UserId)
             .GreaterThan((ulong)0);
 
+        RuleFor(x => x.GuildId)
+            .GreaterThan((ulong)0);
+
         RuleFor(x => x.Query)
             .NotEmpty();
     }

--- a/src/MonkeyButler.Business/Validators/LinkCharacter/LinkCharacterCriteriaValidator.cs
+++ b/src/MonkeyButler.Business/Validators/LinkCharacter/LinkCharacterCriteriaValidator.cs
@@ -1,0 +1,16 @@
+﻿using FluentValidation;
+using MonkeyButler.Abstractions.Business.Models.LinkCharacter;
+
+namespace MonkeyButler.Business.Validators.LinkCharacter;
+
+internal class LinkCharacterCriteriaValidator : AbstractValidator<LinkCharacterCriteria>
+{
+    public LinkCharacterCriteriaValidator()
+    {
+        RuleFor(x => x.UserId)
+            .GreaterThan((ulong)0);
+
+        RuleFor(x => x.Query)
+            .NotEmpty();
+    }
+}

--- a/src/MonkeyButler/Controllers/UserController.cs
+++ b/src/MonkeyButler/Controllers/UserController.cs
@@ -54,7 +54,7 @@ public class UserController : ControllerBase
     public Task PutCollection([FromBody] IDictionary<ulong, IEnumerable<long>> collection) => _userManager.AddCharacterIds(collection);
 
     /// <summary>
-    /// Links a character to the given user Id.
+    /// Links a character to the given user Id (Without verification).
     /// </summary>
     /// <param name="criteria"></param>
     /// <returns></returns>
@@ -74,7 +74,7 @@ public class UserController : ControllerBase
     }
 
     /// <summary>
-    /// Endpoint for verifying a character with a user.
+    /// Verifies a character exists within the guild's FC and links it to the user if so.
     /// </summary>
     /// <param name="criteria"></param>
     /// <returns></returns>

--- a/src/MonkeyButler/Controllers/UserController.cs
+++ b/src/MonkeyButler/Controllers/UserController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using MonkeyButler.Abstractions.Business;
 using MonkeyButler.Abstractions.Business.Models.LinkCharacter;
 using MonkeyButler.Abstractions.Business.Models.User;
+using MonkeyButler.Abstractions.Business.Models.VerifyCharacter;
 
 namespace MonkeyButler.Controllers;
 
@@ -15,14 +16,16 @@ public class UserController : ControllerBase
 {
     private readonly ILinkCharacterManager _linkCharacterManager;
     private readonly IUserManager _userManager;
+    private readonly IVerifyCharacterManager _verifyCharacterManager;
 
     /// <summary>
     /// Constructor
     /// </summary>
-    public UserController(ILinkCharacterManager linkCharacterManager, IUserManager userManager)
+    public UserController(ILinkCharacterManager linkCharacterManager, IUserManager userManager, IVerifyCharacterManager verifyCharacterManager)
     {
         _linkCharacterManager = linkCharacterManager ?? throw new ArgumentNullException(nameof(linkCharacterManager));
         _userManager = userManager ?? throw new ArgumentNullException(nameof(userManager));
+        _verifyCharacterManager = verifyCharacterManager ?? throw new ArgumentNullException(nameof(verifyCharacterManager));
     }
 
     /// <summary>
@@ -56,13 +59,33 @@ public class UserController : ControllerBase
     /// <param name="criteria"></param>
     /// <returns></returns>
     [HttpPost("Link")]
-    [ProducesDefaultResponseType()]
+    [ProducesDefaultResponseType(typeof(LinkCharacterResult))]
     [ProducesResponseType((int)HttpStatusCode.BadRequest)]
     public async Task<LinkCharacterResult> LinkCharacter([FromBody] LinkCharacterCriteria criteria)
     {
         var result = await _linkCharacterManager.Process(criteria);
 
         if (!result.Success)
+        {
+            Response.StatusCode = (int)HttpStatusCode.BadRequest;
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Endpoint for verifying a character with a user.
+    /// </summary>
+    /// <param name="criteria"></param>
+    /// <returns></returns>
+    [HttpPost("Verify")]
+    [ProducesDefaultResponseType(typeof(VerifyCharacterResult))]
+    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+    public async Task<VerifyCharacterResult> VerifyCharacter([FromBody] VerifyCharacterCriteria criteria)
+    {
+        var result = await _verifyCharacterManager.Process(criteria);
+
+        if (result.Status != Status.Verified)
         {
             Response.StatusCode = (int)HttpStatusCode.BadRequest;
         }

--- a/src/MonkeyButler/Controllers/UserController.cs
+++ b/src/MonkeyButler/Controllers/UserController.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net;
 using Microsoft.AspNetCore.Mvc;
 using MonkeyButler.Abstractions.Business;
+using MonkeyButler.Abstractions.Business.Models.LinkCharacter;
 using MonkeyButler.Abstractions.Business.Models.User;
 
 namespace MonkeyButler.Controllers;
@@ -12,13 +13,15 @@ namespace MonkeyButler.Controllers;
 [Route("api/[controller]")]
 public class UserController : ControllerBase
 {
+    private readonly ILinkCharacterManager _linkCharacterManager;
     private readonly IUserManager _userManager;
 
     /// <summary>
     /// Constructor
     /// </summary>
-    public UserController(IUserManager userManager)
+    public UserController(ILinkCharacterManager linkCharacterManager, IUserManager userManager)
     {
+        _linkCharacterManager = linkCharacterManager ?? throw new ArgumentNullException(nameof(linkCharacterManager));
         _userManager = userManager ?? throw new ArgumentNullException(nameof(userManager));
     }
 
@@ -46,4 +49,24 @@ public class UserController : ControllerBase
     [ProducesDefaultResponseType()]
     [ProducesResponseType((int)HttpStatusCode.BadRequest)]
     public Task PutCollection([FromBody] IDictionary<ulong, IEnumerable<long>> collection) => _userManager.AddCharacterIds(collection);
+
+    /// <summary>
+    /// Links a character to the given user Id.
+    /// </summary>
+    /// <param name="criteria"></param>
+    /// <returns></returns>
+    [HttpPost("Link")]
+    [ProducesDefaultResponseType()]
+    [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+    public async Task<LinkCharacterResult> LinkCharacter([FromBody] LinkCharacterCriteria criteria)
+    {
+        var result = await _linkCharacterManager.Process(criteria);
+
+        if (!result.Success)
+        {
+            Response.StatusCode = (int)HttpStatusCode.BadRequest;
+        }
+
+        return result;
+    }
 }

--- a/tests/MonkeyButler.Business.Tests/Managers/LinkCharacterManagerTests.cs
+++ b/tests/MonkeyButler.Business.Tests/Managers/LinkCharacterManagerTests.cs
@@ -50,7 +50,25 @@ public class LinkCharacterManagerTests
         var result = await _manager.Process(criteria);
 
         Assert.True(result.Success);
+        Assert.Equal(89439, result.CharacterId);
         _userAccessorMock.Verify(x => x.SaveUser(It.Is<User>(u => 
             u.Id == 1234 && u.CharacterIds.Contains(89439))));
+    }
+
+    [Fact]
+    public async Task NoCharacterShouldNotLink()
+    {
+        _searchResult.Results = new();
+        var criteria = new LinkCharacterCriteria()
+        {
+            UserId = 1234,
+            GuildId = 2345,
+            Query = "Jolinar Cast"
+        };
+
+        var result = await _manager.Process(criteria);
+
+        Assert.False(result.Success);
+        _userAccessorMock.Verify(x => x.SaveUser(It.IsAny<User>()), Times.Never);
     }
 }

--- a/tests/MonkeyButler.Business.Tests/Managers/LinkCharacterManagerTests.cs
+++ b/tests/MonkeyButler.Business.Tests/Managers/LinkCharacterManagerTests.cs
@@ -1,0 +1,56 @@
+﻿using MonkeyButler.Abstractions.Business;
+using MonkeyButler.Abstractions.Business.Models.LinkCharacter;
+using MonkeyButler.Abstractions.Data.Api;
+using MonkeyButler.Abstractions.Data.Api.Models.XivApi.Character;
+using MonkeyButler.Abstractions.Data.Storage;
+using MonkeyButler.Abstractions.Data.Storage.Models.User;
+using MonkeyButler.Business.Managers;
+using Moq;
+using Xunit;
+
+namespace MonkeyButler.Business.Tests.Managers;
+
+public class LinkCharacterManagerTests
+{
+    private readonly Mock<IGuildOptionsAccessor> _guildOptionsAccessorMock = new();
+    private readonly Mock<IUserAccessor> _userAccessorMock = new();
+    private readonly Mock<IXivApiAccessor> _xivApiAccessorMock = new();
+
+    private SearchCharacterData _searchResult = new();
+
+    public LinkCharacterManagerTests()
+    {
+        _xivApiAccessorMock.Setup(x => x.SearchCharacter(It.IsAny<SearchCharacterQuery>()))
+            .ReturnsAsync(_searchResult);
+    }
+
+    private ILinkCharacterManager _manager => Resolver
+        .Add(_guildOptionsAccessorMock.Object)
+        .Add(_userAccessorMock.Object)
+        .Add(_xivApiAccessorMock.Object)
+        .Resolve<LinkCharacterManager>();
+
+    [Fact]
+    public async Task CharacterShouldLink()
+    {
+        _searchResult.Results = new()
+        {
+            new()
+            {
+                Id = 89439
+            }
+        };
+        var criteria = new LinkCharacterCriteria()
+        {
+            UserId = 1234,
+            GuildId = 2345,
+            Query = "Jolinar Cast"
+        };
+
+        var result = await _manager.Process(criteria);
+
+        Assert.True(result.Success);
+        _userAccessorMock.Verify(x => x.SaveUser(It.Is<User>(u => 
+            u.Id == 1234 && u.CharacterIds.Contains(89439))));
+    }
+}

--- a/tests/MonkeyButler.Business.Tests/Managers/VerifyCharacterManagerTests.cs
+++ b/tests/MonkeyButler.Business.Tests/Managers/VerifyCharacterManagerTests.cs
@@ -192,4 +192,14 @@ public class VerifyCharacterManagerTests
 
         Assert.Equal(Status.CharacterAlreadyVerified, result.Status);
     }
+
+    [Fact]
+    public async Task VerifiedShouldReturnVerifiedUserId()
+    {
+        var criteria = _defaultCriteria;
+
+        var result = await _manager.Process(criteria);
+
+        Assert.Equal(_userId, result.VerifiedUserId);
+    }
 }


### PR DESCRIPTION
This adds two endpoints for managing users via the api:

- Link Character
  - Links a character to a user without verification
- Verify Character
  - Existing business logic to verify a character with a user via the guild's FC